### PR TITLE
deps: go 1.16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
       - run: |
           go get -v -t -d ./...
       - run: |

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 gofor-little
+Copyright (c) 2021 gofor-little
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gofor-little/colors
 
-go 1.15
+go 1.16


### PR DESCRIPTION
- Added Go 1.16 support.
- Updated LICENSE year.
- Updated CI action.